### PR TITLE
Feature/empty package

### DIFF
--- a/hammer/fpm.go
+++ b/hammer/fpm.go
@@ -143,9 +143,18 @@ func (f *FPM) setBaseArgs() error {
 }
 
 func (f *FPM) setBaseOpts() error {
-	opts := []string{
-		"-s", "dir",
-		"-p", f.Package.OutputRoot,
+	var opts []string
+
+	if len(f.Package.Targets) == 0 {
+		opts = []string{
+			"-s", "empty",
+			"-p", f.Package.OutputRoot,
+		}
+	} else {
+		opts = []string{
+			"-s", "dir",
+			"-p", f.Package.OutputRoot,
+		}
 	}
 
 	type Source func() ([]string, error)

--- a/hammer/resource.go
+++ b/hammer/resource.go
@@ -3,6 +3,7 @@ package hammer
 import (
 	"crypto/md5"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"github.com/Sirupsen/logrus"
@@ -117,6 +118,10 @@ func (s *Resource) sum(body []byte) (string, error) {
 		hasher = md5.New()
 	case "sha1":
 		hasher = sha1.New()
+	case "sha256":
+		hasher = sha256.New()
+	case "sha224":
+		hasher = sha256.New224()
 	default:
 		return "", ErrBadHashType
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ import (
 	"runtime"
 )
 
+const Name = "hammer"
+const Version = "0.2"
+
 var (
 	rootCmd = &cobra.Command{
 		Use:   "hammer",


### PR DESCRIPTION
Use `-s empty` when there are no targets in the spec file. This allows the creation of meta packages.
