### PR TITLE
Add `obsoletes` section to package

### DIFF
--- a/hammer/fpm.go
+++ b/hammer/fpm.go
@@ -161,6 +161,7 @@ func (f *FPM) setBaseOpts() error {
 	fieldSources := []Source{
 		f.baseFields,
 		f.baseDependencies,
+		f.baseObsoletes,
 		f.baseScripts,
 		f.baseConfigs,
 	}
@@ -235,6 +236,24 @@ func (f *FPM) baseDependencies() ([]string, error) {
 			return opts, err
 		}
 		opts = append(opts, "--depends", depend.String())
+	}
+
+	return opts, nil
+}
+
+func (f *FPM) baseObsoletes() ([]string, error) {
+	opts := []string{}
+
+	for _, rawObsolete := range f.Package.Obsoletes {
+		obsolete, err := f.Package.template.Render(rawObsolete)
+		if err != nil {
+			f.Package.logger.WithFields(logrus.Fields{
+				"error": err,
+				"raw":   rawObsolete,
+			}).Error("failed to render obsolete as template")
+			return opts, err
+		}
+		opts = append(opts, "--replaces", obsolete.String())
 	}
 
 	return opts, nil

--- a/hammer/package.go
+++ b/hammer/package.go
@@ -35,6 +35,7 @@ type Package struct {
 	Iteration    string     `yaml:"iteration,omitempty"`
 	License      string     `yaml:"license,omitempty"`
 	Name         string     `yaml:"name,omitempty"`
+	Obsoletes    []string   `yaml:"obsoletes,omitempty"`
 	Resources    []Resource `yaml:"resources,omitempty"`
 	Scripts      Scripts    `yaml:"scripts,omitempty"`
 	Targets      []Target   `yaml:"targets,omitempty"`


### PR DESCRIPTION
Adds an `obsoletes` section to the package. This provides an upgrade path for changing package names. 

An example would be a move from a `consul-utils` to `consul-cli`. The `spec.yml` for the consul-cli package contains the lines:

``` yaml
obsoletes:
  - consul-util
```

When installing on a host with `consul-utils` installed the old package is removed and the new package installed.

``` shell
bash-4.2# rpm -Uvh consul-cli-0.1.0-2.x86_64.rpm 
Preparing...                          ################################# [100%]
Updating / installing...
   1:consul-cli-0.1.0-2               ################################# [ 50%]
Cleaning up / removing...
   2:consul-utils-0.1.0-1.el7.centos  ################################# [100%]
```
