### PR TITLE
Add flag to skip cleanup step during build

### DIFF
--- a/hammer/package.go
+++ b/hammer/package.go
@@ -133,9 +133,15 @@ func (p *Package) SetCache(cache cache.Cache) {
 // cleanup.
 func (p *Package) BuildAndPackage() error {
 	defer func() {
-		err := p.Cleanup()
-		if err != nil {
-			p.logger.Warn("did not clean up successfully, there may be residual files in your system")
+		// TODO: remove the call to viper here in favor of having another piece
+		// of configuration in Package
+		if !viper.GetBool("skip-cleanup") {
+			err := p.Cleanup()
+			if err != nil {
+				p.logger.Warn("did not clean up successfully, there may be residual files in your system")
+			}
+		} else {
+			p.logger.Info("Flag --skip-cleanup was specified, skipping cleanup")
 		}
 	}()
 	type Stage struct {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func init() {
 	buildCmd.Flags().String("output", path.Join(cwd, "out"), "where to place output packages")
 	buildCmd.Flags().String("logs", path.Join(cwd, "logs"), "where to place build logs")
 	buildCmd.Flags().String("cache", path.Join(cwd, ".hammer-cache"), "where to cache downloads")
+	buildCmd.Flags().Bool("skip-cleanup", false, "skip cleanup step")
 
 	for _, flags := range []*pflag.FlagSet{rootCmd.PersistentFlags(), buildCmd.Flags()} {
 		err := viper.BindPFlags(flags)


### PR DESCRIPTION
This can be useful for debugging build scripts, e.g. if you get a "file not found"-type error from FPM. 
