### PR TITLE
info is nil in loader.go `Load()` work around

### DIFF
--- a/hammer/loader.go
+++ b/hammer/loader.go
@@ -1,11 +1,12 @@
 package hammer
 
 import (
-	"github.com/Sirupsen/logrus"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // Loader looks for Package specs in a given root.
@@ -31,7 +32,8 @@ func (l *Loader) Load() ([]*Package, error) {
 	packages := []*Package{}
 
 	err := filepath.Walk(l.Root, func(pathName string, info os.FileInfo, err error) error {
-		if info.IsDir() || info.Name() != l.Indicator {
+
+		if info == nil || info.IsDir() || info.Name() != l.Indicator {
 			return nil
 		}
 


### PR DESCRIPTION
When running hammer build in the mantl-packaging vagrant environment, Hammer
panics. For some reason info is nil. I did not look much into the cause.
